### PR TITLE
Don't unclass participant id column

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -164,7 +164,8 @@ tractr_single_bundle <- function(df_afq = NULL,
     df_afq[[group.by]] <- factor(df_afq[[group.by]])
   }
 
-  df_afq[[participant.id]] <- unclass(factor(df_afq[[participant.id]]))
+  # Make sure that the participant ID is stored as a factor:
+  df_afq[[participant.id]] <- factor(df_afq[[participant.id]])
 
   cols <- unique(c(participant.id,
                    "nodeID",


### PR DESCRIPTION
This change seems to be related to very small p-values that we've observed in past use of tractr. 

@SendyCaffarra : can you give this branch a try with the HBN data and let me know if you run into any issues? 