### PR TITLE
Fix quote syntax error in workflow files

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -8,7 +8,7 @@ name: document
 
 jobs:
   document:
-    if: ${{ github.event.status == "success" && startsWith(github.event.head_commit.message, "Merge pull request") }}
+    if: ${{ github.event.status == 'success' && startsWith(github.event.head_commit.message, 'Merge pull request') }}
     name: document
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Cannot use double quotes iin workflow `yaml` files.